### PR TITLE
update etagHeader to ifNoneMatchHeader in request header

### DIFF
--- a/lib/src/dio_cache_interceptor.dart
+++ b/lib/src/dio_cache_interceptor.dart
@@ -106,7 +106,7 @@ class DioCacheInterceptor extends Interceptor {
 
   void _addCacheDirectives(RequestOptions request, CacheResponse response) {
     if (response.eTag != null) {
-      request.headers[HttpHeaders.etagHeader] = response.eTag;
+      request.headers[HttpHeaders.ifNoneMatchHeader] = response.eTag;
     }
     if (response.lastModified != null) {
       request.headers[HttpHeaders.ifModifiedSinceHeader] =


### PR DESCRIPTION
When using the eTag cache, The right header in request should be 'if-None-Match'. not 'eTag'.