### PR TITLE
maxStale alone never send back cache

### DIFF
--- a/dio_cache_interceptor/lib/src/dio_cache_interceptor.dart
+++ b/dio_cache_interceptor/lib/src/dio_cache_interceptor.dart
@@ -109,10 +109,14 @@ class DioCacheInterceptor extends Interceptor {
       returnResponse = true;
     } else {
       // Check if we can return cache
-      final hcoeExcept = options.hitCacheOnErrorExcept;
+      final maxStale = options.maxStale;
 
-      if (hcoeExcept != null) {
+      if (maxStale != null) {
+        final hcoeExcept = options.hitCacheOnErrorExcept;
+
         if (errResponse == null) {
+          returnResponse = true;
+        } else if (hcoeExcept == null) {
           returnResponse = true;
         } else if (!hcoeExcept.contains(errResponse.statusCode)) {
           returnResponse = true;


### PR DESCRIPTION
Hello,

Thanks a lot for your work, your package is really helpful.

I found an issue in DioCacheInterceptor.onError. If I define a Duration for maxStale but I don't define any exception for hitCacheOnErrorExcept, interceptor never send me back my cache when an error occurs (for example : an error 500). In my case, I don't want to define any exception.

Hope this helps !