### PR TITLE
Add objectbox store

### DIFF
--- a/dio_cache_interceptor_objectbox_store/.gitignore
+++ b/dio_cache_interceptor_objectbox_store/.gitignore
@@ -1,0 +1,43 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+/build/
+
+# Web related
+lib/generated_plugin_registrant.dart
+
+# Symbolication related
+app.*.symbols
+
+# Obfuscation related
+app.*.map.json
+
+# Exceptions to above rules.
+!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages

--- a/dio_cache_interceptor_objectbox_store/CHANGELOG.md
+++ b/dio_cache_interceptor_objectbox_store/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+* Initial release

--- a/dio_cache_interceptor_objectbox_store/LICENSE
+++ b/dio_cache_interceptor_objectbox_store/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/dio_cache_interceptor_objectbox_store/README.md
+++ b/dio_cache_interceptor_objectbox_store/README.md
@@ -1,3 +1,11 @@
 # dio_cache_interceptor_objectbox_store
 
 ObjectBox cache store implementation.
+
+## Tests
+
+In order to run unit tests locally on your machine, install the native ObjectBox library on your host machine:
+
+```bash
+bash <(curl -s https://raw.githubusercontent.com/objectbox/objectbox-dart/main/install.sh)
+```

--- a/dio_cache_interceptor_objectbox_store/README.md
+++ b/dio_cache_interceptor_objectbox_store/README.md
@@ -1,0 +1,3 @@
+# dio_cache_interceptor_objectbox_store
+
+ObjectBox cache store implementation.

--- a/dio_cache_interceptor_objectbox_store/analysis_options.yaml
+++ b/dio_cache_interceptor_objectbox_store/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:pedantic/analysis_options.yaml
+
+analyzer:
+  exclude:
+    - "example/**"

--- a/dio_cache_interceptor_objectbox_store/lib/dio_cache_interceptor_objectbox_store.dart
+++ b/dio_cache_interceptor_objectbox_store/lib/dio_cache_interceptor_objectbox_store.dart
@@ -1,0 +1,3 @@
+library dio_cache_interceptor_objectbox_store;
+
+export 'src/store/dio_cache_interceptor_objectbox_store.dart';

--- a/dio_cache_interceptor_objectbox_store/lib/objectbox-model.json
+++ b/dio_cache_interceptor_objectbox_store/lib/objectbox-model.json
@@ -1,0 +1,134 @@
+{
+  "_note1": "KEEP THIS FILE! Check it into a version control system (VCS) like git.",
+  "_note2": "ObjectBox manages crucial IDs for your object model. See docs for details.",
+  "_note3": "If you have VCS merge conflicts, you must resolve them according to ObjectBox docs.",
+  "entities": [
+    {
+      "id": "1:1354879783786486451",
+      "lastPropertyId": "6:3554148799202003267",
+      "name": "CacheControlBox",
+      "properties": [
+        {
+          "id": "1:7542048865731308062",
+          "name": "id",
+          "type": 6,
+          "flags": 1
+        },
+        {
+          "id": "2:5058379695187648266",
+          "name": "maxAge",
+          "type": 6
+        },
+        {
+          "id": "3:6729461042167174602",
+          "name": "privacy",
+          "type": 9
+        },
+        {
+          "id": "4:3984935714719910661",
+          "name": "noCache",
+          "type": 1
+        },
+        {
+          "id": "5:4279848142252840831",
+          "name": "noStore",
+          "type": 1
+        },
+        {
+          "id": "6:3554148799202003267",
+          "name": "other",
+          "type": 30
+        }
+      ],
+      "relations": []
+    },
+    {
+      "id": "2:3591291115973887432",
+      "lastPropertyId": "13:4287785650979561948",
+      "name": "CacheResponseBox",
+      "properties": [
+        {
+          "id": "1:5681174421901306941",
+          "name": "id",
+          "type": 6,
+          "flags": 1
+        },
+        {
+          "id": "2:2558701747622840298",
+          "name": "key",
+          "type": 9
+        },
+        {
+          "id": "3:3817824292323352053",
+          "name": "content",
+          "type": 23
+        },
+        {
+          "id": "4:6117783729881623912",
+          "name": "date",
+          "type": 10
+        },
+        {
+          "id": "5:3535461758765559380",
+          "name": "eTag",
+          "type": 9
+        },
+        {
+          "id": "6:365079362971753198",
+          "name": "expires",
+          "type": 10
+        },
+        {
+          "id": "7:9154450730268381409",
+          "name": "headers",
+          "type": 23
+        },
+        {
+          "id": "8:2810219807190022652",
+          "name": "lastModified",
+          "type": 9
+        },
+        {
+          "id": "9:2228972762576331614",
+          "name": "maxStale",
+          "type": 10
+        },
+        {
+          "id": "10:357520955945404792",
+          "name": "responseDate",
+          "type": 10
+        },
+        {
+          "id": "11:8589375812343335305",
+          "name": "url",
+          "type": 9
+        },
+        {
+          "id": "12:2042507747744468765",
+          "name": "priority",
+          "type": 6
+        },
+        {
+          "id": "13:4287785650979561948",
+          "name": "cacheControlId",
+          "type": 11,
+          "flags": 520,
+          "indexId": "1:8984911200634127343",
+          "relationTarget": "CacheControlBox"
+        }
+      ],
+      "relations": []
+    }
+  ],
+  "lastEntityId": "2:3591291115973887432",
+  "lastIndexId": "1:8984911200634127343",
+  "lastRelationId": "0:0",
+  "lastSequenceId": "0:0",
+  "modelVersion": 5,
+  "modelVersionParserMinimum": 5,
+  "retiredEntityUids": [],
+  "retiredIndexUids": [],
+  "retiredPropertyUids": [],
+  "retiredRelationUids": [],
+  "version": 1
+}

--- a/dio_cache_interceptor_objectbox_store/lib/objectbox.g.dart
+++ b/dio_cache_interceptor_objectbox_store/lib/objectbox.g.dart
@@ -1,0 +1,376 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: camel_case_types
+
+import 'dart:typed_data';
+
+import 'package:objectbox/flatbuffers/flat_buffers.dart' as fb;
+import 'package:objectbox/internal.dart'; // generated code can access "internal" functionality
+import 'package:objectbox/objectbox.dart';
+
+import 'src/store/dio_cache_interceptor_objectbox_store.dart';
+
+export 'package:objectbox/objectbox.dart'; // so that callers only have to import this file
+
+final _entities = <ModelEntity>[
+  ModelEntity(
+      id: const IdUid(1, 1354879783786486451),
+      name: 'CacheControlBox',
+      lastPropertyId: const IdUid(6, 3554148799202003267),
+      flags: 0,
+      properties: <ModelProperty>[
+        ModelProperty(
+            id: const IdUid(1, 7542048865731308062),
+            name: 'id',
+            type: 6,
+            flags: 1),
+        ModelProperty(
+            id: const IdUid(2, 5058379695187648266),
+            name: 'maxAge',
+            type: 6,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(3, 6729461042167174602),
+            name: 'privacy',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(4, 3984935714719910661),
+            name: 'noCache',
+            type: 1,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(5, 4279848142252840831),
+            name: 'noStore',
+            type: 1,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(6, 3554148799202003267),
+            name: 'other',
+            type: 30,
+            flags: 0)
+      ],
+      relations: <ModelRelation>[],
+      backlinks: <ModelBacklink>[]),
+  ModelEntity(
+      id: const IdUid(2, 3591291115973887432),
+      name: 'CacheResponseBox',
+      lastPropertyId: const IdUid(13, 4287785650979561948),
+      flags: 0,
+      properties: <ModelProperty>[
+        ModelProperty(
+            id: const IdUid(1, 5681174421901306941),
+            name: 'id',
+            type: 6,
+            flags: 1),
+        ModelProperty(
+            id: const IdUid(2, 2558701747622840298),
+            name: 'key',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(3, 3817824292323352053),
+            name: 'content',
+            type: 23,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(4, 6117783729881623912),
+            name: 'date',
+            type: 10,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(5, 3535461758765559380),
+            name: 'eTag',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(6, 365079362971753198),
+            name: 'expires',
+            type: 10,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(7, 9154450730268381409),
+            name: 'headers',
+            type: 23,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(8, 2810219807190022652),
+            name: 'lastModified',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(9, 2228972762576331614),
+            name: 'maxStale',
+            type: 10,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(10, 357520955945404792),
+            name: 'responseDate',
+            type: 10,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(11, 8589375812343335305),
+            name: 'url',
+            type: 9,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(12, 2042507747744468765),
+            name: 'priority',
+            type: 6,
+            flags: 0),
+        ModelProperty(
+            id: const IdUid(13, 4287785650979561948),
+            name: 'cacheControlId',
+            type: 11,
+            flags: 520,
+            indexId: const IdUid(1, 8984911200634127343),
+            relationTarget: 'CacheControlBox')
+      ],
+      relations: <ModelRelation>[],
+      backlinks: <ModelBacklink>[])
+];
+
+/// Open an ObjectBox store with the model declared in this file.
+Store openStore(
+        {String? directory,
+        int? maxDBSizeInKB,
+        int? fileMode,
+        int? maxReaders,
+        bool queriesCaseSensitiveDefault = true,
+        String? macosApplicationGroup}) =>
+    Store(getObjectBoxModel(),
+        directory: directory,
+        maxDBSizeInKB: maxDBSizeInKB,
+        fileMode: fileMode,
+        maxReaders: maxReaders,
+        queriesCaseSensitiveDefault: queriesCaseSensitiveDefault,
+        macosApplicationGroup: macosApplicationGroup);
+
+/// ObjectBox model definition, pass it to [Store] - Store(getObjectBoxModel())
+ModelDefinition getObjectBoxModel() {
+  final model = ModelInfo(
+      entities: _entities,
+      lastEntityId: const IdUid(2, 3591291115973887432),
+      lastIndexId: const IdUid(1, 8984911200634127343),
+      lastRelationId: const IdUid(0, 0),
+      lastSequenceId: const IdUid(0, 0),
+      retiredEntityUids: const [],
+      retiredIndexUids: const [],
+      retiredPropertyUids: const [],
+      retiredRelationUids: const [],
+      modelVersion: 5,
+      modelVersionParserMinimum: 5,
+      version: 1);
+
+  final bindings = <Type, EntityDefinition>{
+    CacheControlBox: EntityDefinition<CacheControlBox>(
+        model: _entities[0],
+        toOneRelations: (CacheControlBox object) => [],
+        toManyRelations: (CacheControlBox object) => {},
+        getId: (CacheControlBox object) => object.id,
+        setId: (CacheControlBox object, int id) {
+          object.id = id;
+        },
+        objectToFB: (CacheControlBox object, fb.Builder fbb) {
+          final privacyOffset =
+              object.privacy == null ? null : fbb.writeString(object.privacy!);
+          final otherOffset = object.other == null
+              ? null
+              : fbb.writeList(
+                  object.other!.map(fbb.writeString).toList(growable: false));
+          fbb.startTable(7);
+          fbb.addInt64(0, object.id ?? 0);
+          fbb.addInt64(1, object.maxAge);
+          fbb.addOffset(2, privacyOffset);
+          fbb.addBool(3, object.noCache);
+          fbb.addBool(4, object.noStore);
+          fbb.addOffset(5, otherOffset);
+          fbb.finish(fbb.endTable());
+          return object.id ?? 0;
+        },
+        objectFromFB: (Store store, ByteData fbData) {
+          final buffer = fb.BufferContext(fbData);
+          final rootOffset = buffer.derefObject(0);
+
+          final object = CacheControlBox(
+              id: const fb.Int64Reader()
+                  .vTableGetNullable(buffer, rootOffset, 4),
+              maxAge: const fb.Int64Reader()
+                  .vTableGetNullable(buffer, rootOffset, 6),
+              privacy: const fb.StringReader()
+                  .vTableGetNullable(buffer, rootOffset, 8),
+              noCache: const fb.BoolReader()
+                  .vTableGetNullable(buffer, rootOffset, 10),
+              noStore: const fb.BoolReader()
+                  .vTableGetNullable(buffer, rootOffset, 12),
+              other: const fb.ListReader<String>(fb.StringReader(), lazy: false)
+                  .vTableGetNullable(buffer, rootOffset, 14));
+
+          return object;
+        }),
+    CacheResponseBox: EntityDefinition<CacheResponseBox>(
+        model: _entities[1],
+        toOneRelations: (CacheResponseBox object) => [object.cacheControl],
+        toManyRelations: (CacheResponseBox object) => {},
+        getId: (CacheResponseBox object) => object.id,
+        setId: (CacheResponseBox object, int id) {
+          object.id = id;
+        },
+        objectToFB: (CacheResponseBox object, fb.Builder fbb) {
+          final keyOffset = fbb.writeString(object.key);
+          final contentOffset = object.content == null
+              ? null
+              : fbb.writeListInt8(object.content!);
+          final eTagOffset =
+              object.eTag == null ? null : fbb.writeString(object.eTag!);
+          final headersOffset = object.headers == null
+              ? null
+              : fbb.writeListInt8(object.headers!);
+          final lastModifiedOffset = object.lastModified == null
+              ? null
+              : fbb.writeString(object.lastModified!);
+          final urlOffset = fbb.writeString(object.url);
+          fbb.startTable(14);
+          fbb.addInt64(0, object.id ?? 0);
+          fbb.addOffset(1, keyOffset);
+          fbb.addOffset(2, contentOffset);
+          fbb.addInt64(3, object.date?.millisecondsSinceEpoch);
+          fbb.addOffset(4, eTagOffset);
+          fbb.addInt64(5, object.expires?.millisecondsSinceEpoch);
+          fbb.addOffset(6, headersOffset);
+          fbb.addOffset(7, lastModifiedOffset);
+          fbb.addInt64(8, object.maxStale?.millisecondsSinceEpoch);
+          fbb.addInt64(9, object.responseDate.millisecondsSinceEpoch);
+          fbb.addOffset(10, urlOffset);
+          fbb.addInt64(11, object.priority);
+          fbb.addInt64(12, object.cacheControl.targetId);
+          fbb.finish(fbb.endTable());
+          return object.id ?? 0;
+        },
+        objectFromFB: (Store store, ByteData fbData) {
+          final buffer = fb.BufferContext(fbData);
+          final rootOffset = buffer.derefObject(0);
+          final dateValue =
+              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 10);
+          final expiresValue =
+              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 14);
+          final maxStaleValue =
+              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 20);
+          final object = CacheResponseBox(
+              key: const fb.StringReader().vTableGet(buffer, rootOffset, 6, ''),
+              content: const fb.ListReader<int>(fb.Int8Reader(), lazy: false)
+                  .vTableGetNullable(buffer, rootOffset, 8),
+              date: dateValue == null
+                  ? null
+                  : DateTime.fromMillisecondsSinceEpoch(dateValue),
+              eTag: const fb.StringReader()
+                  .vTableGetNullable(buffer, rootOffset, 12),
+              expires: expiresValue == null
+                  ? null
+                  : DateTime.fromMillisecondsSinceEpoch(expiresValue),
+              headers: const fb.ListReader<int>(fb.Int8Reader(), lazy: false)
+                  .vTableGetNullable(buffer, rootOffset, 16),
+              lastModified: const fb.StringReader()
+                  .vTableGetNullable(buffer, rootOffset, 18),
+              maxStale: maxStaleValue == null
+                  ? null
+                  : DateTime.fromMillisecondsSinceEpoch(maxStaleValue),
+              priority:
+                  const fb.Int64Reader().vTableGet(buffer, rootOffset, 26, 0),
+              responseDate: DateTime.fromMillisecondsSinceEpoch(
+                  const fb.Int64Reader().vTableGet(buffer, rootOffset, 22, 0)),
+              url:
+                  const fb.StringReader().vTableGet(buffer, rootOffset, 24, ''))
+            ..id = const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 4);
+          object.cacheControl.targetId =
+              const fb.Int64Reader().vTableGet(buffer, rootOffset, 28, 0);
+          object.cacheControl.attach(store);
+          return object;
+        })
+  };
+
+  return ModelDefinition(model, bindings);
+}
+
+/// [CacheControlBox] entity fields to define ObjectBox queries.
+class CacheControlBox_ {
+  /// see [CacheControlBox.id]
+  static final id =
+      QueryIntegerProperty<CacheControlBox>(_entities[0].properties[0]);
+
+  /// see [CacheControlBox.maxAge]
+  static final maxAge =
+      QueryIntegerProperty<CacheControlBox>(_entities[0].properties[1]);
+
+  /// see [CacheControlBox.privacy]
+  static final privacy =
+      QueryStringProperty<CacheControlBox>(_entities[0].properties[2]);
+
+  /// see [CacheControlBox.noCache]
+  static final noCache =
+      QueryBooleanProperty<CacheControlBox>(_entities[0].properties[3]);
+
+  /// see [CacheControlBox.noStore]
+  static final noStore =
+      QueryBooleanProperty<CacheControlBox>(_entities[0].properties[4]);
+
+  /// see [CacheControlBox.other]
+  static final other =
+      QueryStringVectorProperty<CacheControlBox>(_entities[0].properties[5]);
+}
+
+/// [CacheResponseBox] entity fields to define ObjectBox queries.
+class CacheResponseBox_ {
+  /// see [CacheResponseBox.id]
+  static final id =
+      QueryIntegerProperty<CacheResponseBox>(_entities[1].properties[0]);
+
+  /// see [CacheResponseBox.key]
+  static final key =
+      QueryStringProperty<CacheResponseBox>(_entities[1].properties[1]);
+
+  /// see [CacheResponseBox.content]
+  static final content =
+      QueryByteVectorProperty<CacheResponseBox>(_entities[1].properties[2]);
+
+  /// see [CacheResponseBox.date]
+  static final date =
+      QueryIntegerProperty<CacheResponseBox>(_entities[1].properties[3]);
+
+  /// see [CacheResponseBox.eTag]
+  static final eTag =
+      QueryStringProperty<CacheResponseBox>(_entities[1].properties[4]);
+
+  /// see [CacheResponseBox.expires]
+  static final expires =
+      QueryIntegerProperty<CacheResponseBox>(_entities[1].properties[5]);
+
+  /// see [CacheResponseBox.headers]
+  static final headers =
+      QueryByteVectorProperty<CacheResponseBox>(_entities[1].properties[6]);
+
+  /// see [CacheResponseBox.lastModified]
+  static final lastModified =
+      QueryStringProperty<CacheResponseBox>(_entities[1].properties[7]);
+
+  /// see [CacheResponseBox.maxStale]
+  static final maxStale =
+      QueryIntegerProperty<CacheResponseBox>(_entities[1].properties[8]);
+
+  /// see [CacheResponseBox.responseDate]
+  static final responseDate =
+      QueryIntegerProperty<CacheResponseBox>(_entities[1].properties[9]);
+
+  /// see [CacheResponseBox.url]
+  static final url =
+      QueryStringProperty<CacheResponseBox>(_entities[1].properties[10]);
+
+  /// see [CacheResponseBox.priority]
+  static final priority =
+      QueryIntegerProperty<CacheResponseBox>(_entities[1].properties[11]);
+
+  /// see [CacheResponseBox.cacheControl]
+  static final cacheControl =
+      QueryRelationToOne<CacheResponseBox, CacheControlBox>(
+          _entities[1].properties[12]);
+}

--- a/dio_cache_interceptor_objectbox_store/lib/src/store/dio_cache_interceptor_objectbox_store.dart
+++ b/dio_cache_interceptor_objectbox_store/lib/src/store/dio_cache_interceptor_objectbox_store.dart
@@ -1,0 +1,231 @@
+import 'package:dio_cache_interceptor/dio_cache_interceptor.dart';
+import 'package:objectbox/objectbox.dart';
+import 'package:dio_cache_interceptor_objectbox_store/objectbox.g.dart';
+
+/// A store saving responses using ObjectBox.
+///
+class ObjectBoxCacheStore implements CacheStore {
+  /// ObjectBox store file path
+  final String storePath;
+
+  /// ObjectBox store
+  Store? _store;
+
+  /// ObjectBox box instance for [CacheResponseBox]
+  Box<CacheResponseBox>? _box;
+
+  ObjectBoxCacheStore({required this.storePath}) {
+    clean(staleOnly: true);
+  }
+
+  Box<CacheResponseBox> _openBox() {
+    if (_box == null) {
+      _store = Store(getObjectBoxModel(), directory: '$storePath/cache-api');
+      _box = _store!.box<CacheResponseBox>();
+    }
+    return _box!;
+  }
+
+  @override
+  Future<void> clean({
+    CachePriority priorityOrBelow = CachePriority.high,
+    bool staleOnly = false,
+  }) async {
+    final box = _openBox();
+
+    final results = box
+        .query(CacheResponseBox_.priority.lessOrEqual(priorityOrBelow.index))
+        .build()
+        .find();
+
+    for (final result in results) {
+      if ((staleOnly && result.toObject().isStaled()) || !staleOnly) {
+        box.remove(result.id!);
+      }
+    }
+  }
+
+  @override
+  Future<void> close() async {
+    return _store?.close();
+  }
+
+  @override
+  Future<void> delete(String key, {bool staleOnly = false}) async {
+    final box = _openBox();
+    final resp =
+        box.query(CacheResponseBox_.key.equals(key)).build().findFirst();
+    if (resp == null) return Future.value();
+
+    if (staleOnly && !resp.toObject().isStaled()) {
+      return Future.value();
+    }
+
+    box.remove(resp.id!);
+  }
+
+  @override
+  Future<bool> exists(String key) async {
+    final box = _openBox();
+    return box.query(CacheResponseBox_.key.equals(key)).build().findFirst() !=
+        null;
+  }
+
+  @override
+  Future<CacheResponse?> get(String key) async {
+    final box = _openBox();
+    final resp =
+        box.query(CacheResponseBox_.key.equals(key)).build().findFirst();
+    if (resp == null) return null;
+
+    if (resp.toObject().isStaled()) {
+      await delete(key);
+      return null;
+    }
+    return resp.toObject();
+  }
+
+  @override
+  Future<void> set(CacheResponse response) async {
+    final box = _openBox();
+    await delete(response.key);
+    box.put(CacheResponseBox.fromObject(response));
+  }
+}
+
+@Entity()
+class CacheResponseBox {
+  CacheResponseBox({
+    required this.key,
+    this.content,
+    this.date,
+    this.eTag,
+    this.expires,
+    this.headers,
+    this.lastModified,
+    this.maxStale,
+    required this.priority,
+    required this.responseDate,
+    required this.url,
+  });
+
+  @Id()
+  int? id;
+  String key;
+
+  @Property(type: PropertyType.byteVector)
+  List<int>? content;
+
+  @Property(type: PropertyType.date)
+  DateTime? date;
+
+  String? eTag;
+
+  @Property(type: PropertyType.date)
+  DateTime? expires;
+
+  @Property(type: PropertyType.byteVector)
+  List<int>? headers;
+
+  String? lastModified;
+
+  @Property(type: PropertyType.date)
+  DateTime? maxStale;
+
+  @Property(type: PropertyType.date)
+  DateTime responseDate;
+
+  String url;
+
+  int priority;
+
+  final cacheControl = ToOne<CacheControlBox>();
+
+  CachePriority get cachePriority {
+    switch (priority) {
+      case 0:
+        return CachePriority.low;
+      case 1:
+        return CachePriority.normal;
+      case 2:
+        return CachePriority.high;
+      default:
+        return CachePriority.low;
+    }
+  }
+
+  CacheResponse toObject() {
+    return CacheResponse(
+      cacheControl: cacheControl.target?.toObject(),
+      content: content,
+      date: date,
+      eTag: eTag,
+      expires: expires,
+      headers: headers,
+      key: key,
+      lastModified: lastModified,
+      maxStale: maxStale,
+      priority: cachePriority,
+      responseDate: responseDate,
+      url: url,
+    );
+  }
+
+  static CacheResponseBox fromObject(CacheResponse response) {
+    final result = CacheResponseBox(
+      key: response.key,
+      content: response.content,
+      date: response.date,
+      eTag: response.eTag,
+      expires: response.expires,
+      headers: response.headers,
+      lastModified: response.lastModified,
+      maxStale: response.maxStale,
+      responseDate: response.responseDate,
+      url: response.url,
+      priority: response.priority.index,
+    );
+
+    if (response.cacheControl != null) {
+      result.cacheControl.target = CacheControlBox(
+        maxAge: response.cacheControl!.maxAge,
+        privacy: response.cacheControl!.privacy,
+        noCache: response.cacheControl!.noCache,
+        noStore: response.cacheControl!.noStore,
+        other: response.cacheControl!.other,
+      );
+    }
+
+    return result;
+  }
+}
+
+@Entity()
+class CacheControlBox {
+  CacheControlBox({
+    this.id,
+    this.maxAge,
+    this.privacy,
+    this.noCache,
+    this.noStore,
+    this.other,
+  });
+
+  @Id()
+  int? id;
+  int? maxAge;
+  String? privacy;
+  bool? noCache;
+  bool? noStore;
+  List<String>? other;
+
+  CacheControl toObject() {
+    return CacheControl(
+      maxAge: maxAge,
+      privacy: privacy,
+      noCache: noCache,
+      noStore: noStore,
+      other: other ?? [],
+    );
+  }
+}

--- a/dio_cache_interceptor_objectbox_store/pubspec.yaml
+++ b/dio_cache_interceptor_objectbox_store/pubspec.yaml
@@ -1,0 +1,17 @@
+name: dio_cache_interceptor_objectbox_store
+description: A DB cache store implementation with ObjectBox for dio_cache_interceptor package.
+version: 0.0.1
+homepage: https://github.com/llfbandit/dio_cache_interceptor/tree/master/dio_cache_interceptor_objectbox_store
+
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+
+dependencies:
+  dio_cache_interceptor: ^3.0.0
+  objectbox: ^1.2.0
+
+dev_dependencies:
+  build_runner: ^2.1.4
+  objectbox_generator: any
+  pedantic: ^1.11.0
+  test: ^1.16.8

--- a/dio_cache_interceptor_objectbox_store/test/dio_cache_interceptor_objectbox_store_test.dart
+++ b/dio_cache_interceptor_objectbox_store/test/dio_cache_interceptor_objectbox_store_test.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+import 'package:dio_cache_interceptor_objectbox_store/dio_cache_interceptor_objectbox_store.dart';
+import 'package:test/test.dart';
+
+import '../../dio_cache_interceptor/test/common_store_testing.dart';
+
+void main() {
+  late ObjectBoxCacheStore store;
+
+  setUp(() async {
+    store = ObjectBoxCacheStore(storePath: Directory.current.path);
+    await store.clean();
+  });
+
+  tearDown(() async {
+    await store.close();
+  });
+
+  test('Empty by default', () async => await emptyByDefault(store));
+  test('Add item', () async => await addItem(store));
+  test('Get item', () async => await getItem(store));
+  test('Delete item', () async => await deleteItem(store));
+  test('Clean', () async => await clean(store));
+  test('Expires', () async => await expires(store));
+  test('LastModified', () async => await lastModified(store));
+  test('Staled', () async => await staled(store));
+}


### PR DESCRIPTION
This PR adds support for ObjectBox -- https://pub.dev/packages/objectbox.

We use ObjectBox in one of our projects -- opening up a PR if it may be useful to include.

To run unit tests locally the ObjectBox library needs to be installed (as noted https://pub.dev/packages/objectbox):
```
bash <(curl -s https://raw.githubusercontent.com/objectbox/objectbox-dart/main/install.sh)
```