### PR TITLE
fix: Link readme in root folder (#102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+dio_cache_interceptor/README.md


### PR DESCRIPTION
fixed lack of readme in the root folder by symlinking to the readme in the `dio_cache_interceptor` subfolder.
fix #102 