### PR TITLE
修复CacheResponse.fromResponse.lastModified

### DIFF
--- a/dio_cache_interceptor/lib/src/model/cache_response.dart
+++ b/dio_cache_interceptor/lib/src/model/cache_response.dart
@@ -233,7 +233,7 @@ class CacheResponse {
       expires: httpExpiresDate,
       headers: null,
       key: key,
-      lastModified: response.headers[lastModifiedHeader]?.first,
+      lastModified: response.headers[lastModifiedHeader]?.join(","),
       maxStale: checkedMaxStale != null
           ? DateTime.now().toUtc().add(checkedMaxStale)
           : null,


### PR DESCRIPTION
以便在web平台使用dio_cache_interceptor_hive_store