### PR TITLE
Support handling 304 status code in onResponse flow

### DIFF
--- a/dio_cache_interceptor/README.md
+++ b/dio_cache_interceptor/README.md
@@ -61,6 +61,9 @@ final options = const CacheOptions(
   // Default. Allows to cache POST requests.
   // Overriding [keyBuilder] is strongly recommended when [true].
   allowPostMethod: false,
+  // handle not-modified status in response flow
+  // This allows following response interceptors to still be called
+  callResponseInterceptorsAfterNotModified: false,
 );
 
 // Add cache interceptor with global/default options

--- a/dio_cache_interceptor/lib/src/dio_cache_interceptor.dart
+++ b/dio_cache_interceptor/lib/src/dio_cache_interceptor.dart
@@ -30,6 +30,11 @@ class DioCacheInterceptor extends Interceptor {
 
     final cacheOptions = _getCacheOptions(options);
 
+    if (cacheOptions.callResponseInterceptorsAfterNotModified) {
+      // Add 304 as a valid status so onResponse flow is used when a 304 occurs
+      options.validateStatus = (status) => options.validateStatus(status) || status == 304;
+    }
+
     if (_shouldSkip(options, options: cacheOptions)) {
       handler.next(options);
       return;

--- a/dio_cache_interceptor/lib/src/dio_cache_interceptor.dart
+++ b/dio_cache_interceptor/lib/src/dio_cache_interceptor.dart
@@ -214,7 +214,8 @@ class DioCacheInterceptor extends Interceptor {
     if (response != null) {
       // Purge entry if staled
       final maxStale = CacheOptions.fromExtra(request)?.maxStale;
-      if ((maxStale == null || maxStale == const Duration(microseconds: 0)) && response.isStaled()) {
+      if ((maxStale == null || maxStale == const Duration(microseconds: 0)) &&
+          response.isStaled()) {
         await cacheStore.delete(cacheKey);
         return null;
       }
@@ -246,7 +247,8 @@ class DioCacheInterceptor extends Interceptor {
 
       // Update extra fields with cache info
       response.extra[CacheResponse.cacheKey] = cacheResp.key;
-      response.extra[CacheResponse.fromNetwork] = CacheStrategyFactory.allowedStatusCodes.contains(statusCode);
+      response.extra[CacheResponse.fromNetwork] =
+          CacheStrategyFactory.allowedStatusCodes.contains(statusCode);
     }
   }
 

--- a/dio_cache_interceptor/lib/src/model/cache_options.dart
+++ b/dio_cache_interceptor/lib/src/model/cache_options.dart
@@ -77,6 +77,10 @@ class CacheOptions {
   /// allow POST method request to be cached.
   final bool allowPostMethod;
 
+  /// handle not-modified status in response flow
+  /// This allows following response interceptors to still be called
+  final bool callResponseInterceptorsAfterNotModified;
+
   // Key to retrieve options from request
   static const _extraKey = '@cache_options@';
 
@@ -91,6 +95,7 @@ class CacheOptions {
     this.priority = CachePriority.normal,
     this.cipher,
     this.allowPostMethod = false,
+    this.callResponseInterceptorsAfterNotModified = false,
     required this.store,
   });
 
@@ -119,6 +124,7 @@ class CacheOptions {
     CacheStore? store,
     Nullable<CacheCipher>? cipher,
     bool? allowPostMethod,
+    bool? callResponseInterceptorsAfterNotModified,
   }) {
     return CacheOptions(
       policy: policy ?? this.policy,
@@ -131,6 +137,8 @@ class CacheOptions {
       store: store ?? this.store,
       cipher: cipher != null ? cipher.value : this.cipher,
       allowPostMethod: allowPostMethod ?? this.allowPostMethod,
+      callResponseInterceptorsAfterNotModified:
+          callResponseInterceptorsAfterNotModified ?? this.callResponseInterceptorsAfterNotModified,
     );
   }
 }

--- a/dio_cache_interceptor/lib/src/model/cache_options.dart
+++ b/dio_cache_interceptor/lib/src/model/cache_options.dart
@@ -77,10 +77,6 @@ class CacheOptions {
   /// allow POST method request to be cached.
   final bool allowPostMethod;
 
-  /// handle not-modified status in response flow
-  /// This allows following response interceptors to still be called
-  final bool callResponseInterceptorsAfterNotModified;
-
   // Key to retrieve options from request
   static const _extraKey = '@cache_options@';
 
@@ -95,7 +91,6 @@ class CacheOptions {
     this.priority = CachePriority.normal,
     this.cipher,
     this.allowPostMethod = false,
-    this.callResponseInterceptorsAfterNotModified = false,
     required this.store,
   });
 
@@ -124,7 +119,6 @@ class CacheOptions {
     CacheStore? store,
     Nullable<CacheCipher>? cipher,
     bool? allowPostMethod,
-    bool? callResponseInterceptorsAfterNotModified,
   }) {
     return CacheOptions(
       policy: policy ?? this.policy,
@@ -137,8 +131,6 @@ class CacheOptions {
       store: store ?? this.store,
       cipher: cipher != null ? cipher.value : this.cipher,
       allowPostMethod: allowPostMethod ?? this.allowPostMethod,
-      callResponseInterceptorsAfterNotModified:
-          callResponseInterceptorsAfterNotModified ?? this.callResponseInterceptorsAfterNotModified,
     );
   }
 }

--- a/dio_cache_interceptor_db_store/example/pubspec.lock
+++ b/dio_cache_interceptor_db_store/example/pubspec.lock
@@ -13,18 +13,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -122,18 +122,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:
@@ -283,6 +283,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   win32:
     dependency: transitive
     description:
@@ -300,5 +308,5 @@ packages:
     source: hosted
     version: "1.0.0"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=3.0.0"

--- a/dio_cache_interceptor_db_store/pubspec.lock
+++ b/dio_cache_interceptor_db_store/pubspec.lock
@@ -634,4 +634,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=2.19.0 <4.0.0"

--- a/dio_cache_interceptor_hive_store/example/pubspec.lock
+++ b/dio_cache_interceptor_hive_store/example/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.2"
   crypto:
     dependency: transitive
     description:
@@ -86,14 +86,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.5"
   lints:
     dependency: "direct dev"
     description:
@@ -106,18 +98,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
@@ -251,6 +243,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   win32:
     dependency: transitive
     description:
@@ -268,5 +268,5 @@ packages:
     source: hosted
     version: "1.0.0"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.0.0"

--- a/dio_cache_interceptor_hive_store/example/pubspec.lock
+++ b/dio_cache_interceptor_hive_store/example/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   crypto:
     dependency: transitive
     description:
@@ -106,10 +106,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:
@@ -247,10 +247,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "0.3.0"
   win32:
     dependency: transitive
     description:
@@ -268,5 +268,5 @@ packages:
     source: hosted
     version: "1.0.0"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=3.0.0"

--- a/dio_cache_interceptor_hive_store/pubspec.lock
+++ b/dio_cache_interceptor_hive_store/pubspec.lock
@@ -402,4 +402,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=2.19.0 <4.0.0"

--- a/dio_cache_interceptor_sembast_storage/example/pubspec.lock
+++ b/dio_cache_interceptor_sembast_storage/example/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   crypto:
     dependency: transitive
     description:
@@ -78,14 +78,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.5"
   lints:
     dependency: "direct dev"
     description:
@@ -98,18 +90,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:
@@ -259,6 +251,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   win32:
     dependency: transitive
     description:
@@ -276,5 +276,5 @@ packages:
     source: hosted
     version: "1.0.0"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=3.0.0"


### PR DESCRIPTION
In Dio a `304 not modified` can be configured to be a valid status:
`BaseOptions(validateStatus: (status) => status != null && ((status >= 200 && status < 300) || status == 304))`

This PR allows 304's to be handled in the onResponse flow.
This way (having not modified as a valid status) the usual chain of onResponse interceptors will still trigger, unlike the error flow.