### PR TITLE
feat: fast delete for db store

### DIFF
--- a/dio_cache_interceptor_db_store/lib/src/store/database.dart
+++ b/dio_cache_interceptor_db_store/lib/src/store/database.dart
@@ -96,6 +96,11 @@ class DioCacheDao extends DatabaseAccessor<DioCacheDatabase>
     await query.go();
   }
 
+  Future<void> deleteKeys(List<String> keys) async {
+    final query = delete(dioCache)..where((t) => t.cacheKey.isIn(keys));
+    await query.go();
+  }
+
   Future<bool> exists(String key) async {
     final countExp = dioCache.cacheKey.count();
     final query = selectOnly(dioCache)..addColumns([countExp]);
@@ -113,6 +118,14 @@ class DioCacheDao extends DatabaseAccessor<DioCacheDatabase>
     if (result == null) return Future.value();
 
     return mapDataToResponse(result);
+  }
+
+  Future<List<CacheResponse>> getMany(List<String> keys) async {
+    final query = select(dioCache)
+      ..where((t) => t.cacheKey.isIn(keys))
+      ..orderBy([(t) => OrderingTerm(expression: t.date)]);
+
+    return query.get().then((e) => e.map(mapDataToResponse).toList());
   }
 
   Future<void> set(CacheResponse response) async {


### PR DESCRIPTION
The current implementation of deleting cache entries, 
via a given path, in the db cache store implementation, is very slow.

It manually exports 10 database cache entries at a time, 
checks them against the regex and query parameters, and then processes them.

I assume the current implementation has been written with a concern for memory usage in mind,
but as a result can lead to large waiting times.

I propose this new implementation. It conforms to our goals and allows us to speed up the process:

- Search speed: the new implementation directly uses the database engine to execute the Regex matching.
  Because the database cannot do complex query parameter matching, this is done afterwards.
  However, with this we can already exclude large amounts of entries from being searched.
- Memory usage: the new implementation does not export the entirety of the data from the database, resulting in much lower memory usage. Instead, we only fetch the cache key and url, which is enough for the purpose of deleting entries.
- Operation speed: the new implementation executes all database operations at once, using only one transaction for search, and one for delete, allowing faster database code to take over.

The existing test suite for this code runs as expected.
The code introduces no breaking changes and can be released as a patch version.
