### PR TITLE
fix(http_chache_objectobox_store): save bytes array as unsigned bytes

### DIFF
--- a/http_cache_objectbox_store/lib/objectbox.g.dart
+++ b/http_cache_objectbox_store/lib/objectbox.g.dart
@@ -320,9 +320,8 @@ obx_int.ModelDefinition getObjectBoxModel() {
               const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 20);
           final keyParam = const fb.StringReader(asciiOptimization: true)
               .vTableGet(buffer, rootOffset, 6, '');
-          final contentParam =
-              const fb.ListReader<int>(fb.Int8Reader(), lazy: false)
-                  .vTableGetNullable(buffer, rootOffset, 8);
+          final contentParam = const fb.Uint8ListReader(lazy: false)
+              .vTableGetNullable(buffer, rootOffset, 8) as Uint8List?;
           final dateParam = dateValue == null
               ? null
               : DateTime.fromMillisecondsSinceEpoch(dateValue);
@@ -331,9 +330,8 @@ obx_int.ModelDefinition getObjectBoxModel() {
           final expiresParam = expiresValue == null
               ? null
               : DateTime.fromMillisecondsSinceEpoch(expiresValue);
-          final headersParam =
-              const fb.ListReader<int>(fb.Int8Reader(), lazy: false)
-                  .vTableGetNullable(buffer, rootOffset, 16);
+          final headersParam = const fb.Uint8ListReader(lazy: false)
+              .vTableGetNullable(buffer, rootOffset, 16) as Uint8List?;
           final lastModifiedParam =
               const fb.StringReader(asciiOptimization: true)
                   .vTableGetNullable(buffer, rootOffset, 18);

--- a/http_cache_objectbox_store/lib/src/store/http_cache_objectbox_store.dart
+++ b/http_cache_objectbox_store/lib/src/store/http_cache_objectbox_store.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:http_cache_core/http_cache_core.dart';
 // import 'package:objectbox/objectbox.dart';
 import 'package:http_cache_objectbox_store/objectbox.g.dart';
@@ -179,7 +181,7 @@ class CacheResponseBox {
   String key;
 
   @Property(type: PropertyType.byteVector)
-  List<int>? content;
+  Uint8List? content;
 
   @Property(type: PropertyType.date)
   DateTime? date;
@@ -190,7 +192,7 @@ class CacheResponseBox {
   DateTime? expires;
 
   @Property(type: PropertyType.byteVector)
-  List<int>? headers;
+  Uint8List? headers;
 
   String? lastModified;
 
@@ -244,13 +246,16 @@ class CacheResponseBox {
   }
 
   static CacheResponseBox fromObject(CacheResponse response) {
+    final content = response.content;
+    final headers = response.headers;
+
     final result = CacheResponseBox(
       key: response.key,
-      content: response.content,
+      content: content != null ? Uint8List.fromList(content) : null,
       date: response.date,
       eTag: response.eTag,
       expires: response.expires,
-      headers: response.headers,
+      headers: headers != null ? Uint8List.fromList(headers) : null,
       lastModified: response.lastModified,
       maxStale: response.maxStale,
       responseDate: response.responseDate,


### PR DESCRIPTION
A suggestion of using Uint8List instead of List<int> for the content and headers properties of the ResponseCacheBox entity. 
Currently the definition of those 2 properties type them as signed bytes vector (byte ranging from -128 to 127), however http_cache_interceptor encodes/decodes data as utf8 which accepts signed bytes between 0 and 255. 

This is an issue when caching characters with diacritics for example. 

Fixes https://github.com/llfbandit/dart_http_cache/issues/183